### PR TITLE
ci: add Java checks workflow for user-management-service-versapath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI user-management-service-versapath
+name: CI - Java checks
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     branches: [dev]
 
 jobs:
-  build-test:
+  java-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -18,6 +18,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: maven
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -26,6 +27,9 @@ jobs:
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
+
+      - name: Verify dependencies
+        run: mvn -B -DskipTests dependency:resolve
 
       - name: Build with Maven
         run: mvn -B clean install


### PR DESCRIPTION
Adds a minimal CI pipeline to run Java/Maven checks.