### PR TITLE
User Moodle Integration VER 63

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.common</groupId>
             <artifactId>versapath-events</artifactId>
-            <version>1.8.2</version>
+            <version>1.8.9</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capstone/config/RabbitMQConfig.java
+++ b/src/main/java/com/capstone/config/RabbitMQConfig.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 public class RabbitMQConfig {
 
     public static final String USER_EVENT_QUEUE = "versapath.user.created";
+    public static final String UPDATE_USER_QUEUE = "versapath.user.update";
 
     @Bean
     public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
@@ -28,6 +29,11 @@ public class RabbitMQConfig {
     @Bean
     public Queue userEventQueue() {
         return new Queue(USER_EVENT_QUEUE, true);
+    }
+
+    @Bean
+    public Queue updateUserEventQueue() {
+        return new Queue("UPDATE_USER_QUEUE", true);
     }
 
 }

--- a/src/main/java/com/capstone/config/RabbitMQConfig.java
+++ b/src/main/java/com/capstone/config/RabbitMQConfig.java
@@ -31,9 +31,4 @@ public class RabbitMQConfig {
         return new Queue(USER_EVENT_QUEUE, true);
     }
 
-    @Bean
-    public Queue updateUserEventQueue() {
-        return new Queue("UPDATE_USER_QUEUE", true);
-    }
-
 }

--- a/src/main/java/com/capstone/messaging/RabbitMQConsumer.java
+++ b/src/main/java/com/capstone/messaging/RabbitMQConsumer.java
@@ -1,0 +1,31 @@
+package com.capstone.messaging;
+
+import com.capstone.config.RabbitMQConfig;
+import com.capstone.service.UserManagementService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.UpdateUserEvent;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RabbitMQConsumer {
+
+    private final UserManagementService userManagementService;
+
+    @RabbitListener(queues = RabbitMQConfig.UPDATE_USER_QUEUE)
+    public void handleUpdateUserEvent(UpdateUserEvent updateUserEvent) {
+        log.info("Received UpdateUserEvent for versapathUserId: {}", updateUserEvent.getVersapathUserId());
+
+        try {
+            userManagementService.updateMoodleUserId(
+                    updateUserEvent.getVersapathUserId(),
+                    updateUserEvent.getMoodleUserId()
+            );
+        } catch (Exception e) {
+            log.error("Failed to process UpdateUserEvent for user: {}", updateUserEvent.getVersapathUserId(), e);
+        }
+    }
+}

--- a/src/main/java/com/capstone/messaging/RabbitMQProducer.java
+++ b/src/main/java/com/capstone/messaging/RabbitMQProducer.java
@@ -1,7 +1,7 @@
 package com.capstone.messaging;
 
 import lombok.RequiredArgsConstructor;
-import org.common.event.producer.ProduceUserEvent;
+import org.common.event.ProduceUserEvent;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/capstone/service/UserManagementService.java
+++ b/src/main/java/com/capstone/service/UserManagementService.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 public interface UserManagementService {
     UserProfileDto updateUserProfile(ProfileUpdateRequest request);
     void updateUserPassword(PasswordUpdateRequest request);
+    void updateMoodleUserId(UUID versapathUserId, Long moodleUserId);
     
     // Admin user management methods
     PaginatedResponseDto<UserInfoDto> getAllUsers(int page, int size, String sortBy, String sortDirection);

--- a/src/main/java/com/capstone/service/impl/RegistrationServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/RegistrationServiceImpl.java
@@ -6,6 +6,7 @@ import com.capstone.dto.response.*;
 import com.capstone.exception.*;
 import com.capstone.mapper.RegistrationMapper;
 import com.capstone.messaging.RabbitMQProducer;
+import com.capstone.model.ERole;
 import com.capstone.model.EStatus;
 import com.capstone.model.Role;
 import com.capstone.model.User;
@@ -16,7 +17,7 @@ import com.capstone.service.RegistrationService;
 import com.capstone.util.RegistrationTokenUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.common.event.producer.ProduceUserEvent;
+import org.common.event.ProduceUserEvent;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -155,20 +156,25 @@ public class RegistrationServiceImpl implements RegistrationService {
             log.info("Successfully completed registration for user: {} with username: {}",
                     updatedUser.getId(), updatedUser.getUsername());
 
-            try {
-                ProduceUserEvent userEvent = ProduceUserEvent.builder()
-                        .versapathUserId(updatedUser.getId())
-                        .email(updatedUser.getEmail())
-                        .firstName(updatedUser.getFirstName())
-                        .lastName(updatedUser.getLastName())
-                        .username(updatedUser.getUsername())
-                        .build();
+            if (updatedUser.getRole().getRole() == ERole.LEARNER) {
+                try {
+                    ProduceUserEvent userEvent = ProduceUserEvent.builder()
+                            .versapathUserId(updatedUser.getId())
+                            .email(updatedUser.getEmail())
+                            .firstName(updatedUser.getFirstName())
+                            .lastName(updatedUser.getLastName())
+                            .username(updatedUser.getUsername())
+                            .build();
 
-                rabbitMQProducer.sendUserEvent(userEvent);
-                log.info("Successfully published user event for Moodle integration: {}", updatedUser.getUsername());
-            } catch (Exception eventException) {
-                log.error("Failed to publish user event for user: {}", updatedUser.getUsername(), eventException);
-                throw new EventPublishingException("Failed to publish user event for Moodle integration", eventException);
+                    rabbitMQProducer.sendUserEvent(userEvent);
+                    log.info("Successfully published user event for Moodle integration: {} (LEARNER role)", updatedUser.getUsername());
+                } catch (Exception eventException) {
+                    log.error("Failed to publish user event for LEARNER user: {}", updatedUser.getUsername(), eventException);
+                    throw new EventPublishingException("Failed to publish user event for Moodle integration", eventException);
+                }
+            } else {
+                log.info("Skipping Moodle integration event for user: {} (Role: {})",
+                        updatedUser.getUsername(), updatedUser.getRole().getRole());
             }
 
             // Build response

--- a/src/main/java/com/capstone/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/UserManagementServiceImpl.java
@@ -97,6 +97,19 @@ public class UserManagementServiceImpl implements UserManagementService {
         log.info("Password updated successfully for user: {}", currentUser.getEmail());
     }
 
+    @Override
+    public void updateMoodleUserId(UUID versapathUserId, Long moodleUserId) {
+        log.info("Updating moodleUserId for versapathUserId: {} with moodleUserId: {}", versapathUserId, moodleUserId);
+
+        User user = userRepository.findById(versapathUserId)
+                .orElseThrow(() -> new UserNotFoundException("User not found with ID: " + versapathUserId));
+
+        user.setMoodleUserId(moodleUserId);
+        userRepository.save(user);
+
+        log.info("Successfully updated moodleUserId for user: {} ({})", user.getUsername(), user.getEmail());
+    }
+
     private User getCurrentAuthenticatedUser() {
         CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext()
                 .getAuthentication().getPrincipal();

--- a/src/test/java/com/capstone/messaging/RabbitMQProducerTest.java
+++ b/src/test/java/com/capstone/messaging/RabbitMQProducerTest.java
@@ -1,6 +1,6 @@
 package com.capstone.messaging;
 
-import org.common.event.producer.ProduceUserEvent;
+import org.common.event.ProduceUserEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;


### PR DESCRIPTION
# 🚀  Pull Request: Publish User Event Via Rabbit MQ
### 🎫  Jira Ticket
[🔗  SPRINT-1/VER-18: Integration of User registration with moodle via RabbitMQ](https://amali-tech.atlassian.net/browse/VER-63)
---
## ✅  Summary
This PR introduces the implementation of publishing an event when a user of role `LEARNER` is created and consuming back the event when the `moodleUserId` is available to update the Learner details.
---
## 📌  Features  Added 
- [x] RabbitMQ Configuration
- [x] Creation of Event Producer to publish the learner details
- [x] Creation of Event Consumer to consume back the event once the moodleUserId is available 
- [x] Publish event after a user is created 