### PR TITLE
Feat: Populate Created User Kafka Event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.common</groupId>
             <artifactId>versapath-events</artifactId>
-            <version>1.8.9</version>
+            <version>2.2</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -64,6 +64,10 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -151,6 +155,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capstone/messaging/KafkaProducer.java
+++ b/src/main/java/com/capstone/messaging/KafkaProducer.java
@@ -1,0 +1,21 @@
+package com.capstone.messaging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.ProduceUserEvent;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaProducer {
+    private final KafkaTemplate<String, ProduceUserEvent> kafkaTemplate;
+
+    public void produce(ProduceUserEvent event) {
+        log.info("Sending event to Kafka topic: {}", "user.create");
+        kafkaTemplate.send("user.create", event);
+        log.info("user event is populated: {}", event);
+    }
+
+}

--- a/src/main/java/com/capstone/service/impl/RegistrationServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/RegistrationServiceImpl.java
@@ -5,6 +5,7 @@ import com.capstone.dto.request.UserRegistrationRequest;
 import com.capstone.dto.response.*;
 import com.capstone.exception.*;
 import com.capstone.mapper.RegistrationMapper;
+import com.capstone.messaging.KafkaProducer;
 import com.capstone.messaging.RabbitMQProducer;
 import com.capstone.model.ERole;
 import com.capstone.model.EStatus;
@@ -39,6 +40,7 @@ public class RegistrationServiceImpl implements RegistrationService {
     private final RegistrationMapper registrationMapper;
     private final PasswordEncoder passwordEncoder;
     private final RabbitMQProducer rabbitMQProducer;
+    private final KafkaProducer kafkaProducer;
 
 
     @Value("${REGISTRATION_EMAIL_FE_URI}")
@@ -167,7 +169,8 @@ public class RegistrationServiceImpl implements RegistrationService {
                             .build();
 
                     rabbitMQProducer.sendUserEvent(userEvent);
-                    log.info("Successfully published user event for Moodle integration: {} (LEARNER role)", updatedUser.getUsername());
+                    kafkaProducer.produce(userEvent);
+                    log.info("Successfully published user event: {} (LEARNER role)", updatedUser.getUsername());
                 } catch (Exception eventException) {
                     log.error("Failed to publish user event for LEARNER user: {}", updatedUser.getUsername(), eventException);
                     throw new EventPublishingException("Failed to publish user event for Moodle integration", eventException);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,18 @@ spring:
     virtual-host: ${RABBIT_VHOST}
     ssl:
       enabled: true
+
+  kafka:
+    bootstrap-servers: ${BOOTSTRAP_SERVER}
+    properties:
+      sasl.mechanism: PLAIN
+      sasl.jaas.config: >
+        org.apache.kafka.common.security.plain.PlainLoginModule required
+        username='${KAFKA_API_KEY}'
+        password='${KAFKA_API_SECRET}';
+      security.protocol: SASL_SSL
+      session.timeout.ms: 45000
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
# 🚀  Pull Request: Kafka User Event Implementation
---
## ✅  Summary
This PR provides the implementation of publishing a kafka event when a user is created for the roadmap service to store some of the user(`Learner`) details.
---
## 📌  Features  Added 
- [x] Kafka Event Producer
- [x] Publish event after a user is created 