### PR TITLE
Fix: Add User Profile Picture during Event Publish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.common</groupId>
             <artifactId>versapath-events</artifactId>
-            <version>3.1.1</version>
+            <version>3.1.6</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capstone/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/LoginResponseDto.java
@@ -37,6 +37,9 @@ public class LoginResponseDto {
     @Schema(description = "User's role name", example = "ADMIN")
     private String role;
 
+    @Schema(description = "Moodle user ID (only for learners)", example = "12345")
+    private Long moodleUserId;
+
     @Schema(description = "Indicates if user needs onboarding", example = "true")
     private boolean requiresOnboarding;
 }

--- a/src/main/java/com/capstone/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/AuthenticationServiceImpl.java
@@ -148,6 +148,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                 .phoneNumber(user.getPhoneNumber())
                 .profilePictureUrl(profilePictureUrl)
                 .role(user.getRole().getRole().name())
+                .moodleUserId(user.getRole().getRole() == ERole.LEARNER ? user.getMoodleUserId() : null)
                 .requiresOnboarding(user.isNewUser() && user.getRole().getRole() == ERole.LEARNER)
                 .build();
 

--- a/src/main/java/com/capstone/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/UserManagementServiceImpl.java
@@ -123,6 +123,7 @@ public class UserManagementServiceImpl implements UserManagementService {
                         .firstName(updatedUser.getFirstName())
                         .lastName(updatedUser.getLastName())
                         .username(updatedUser.getUsername())
+                        .imageUrl(updatedUser.getProfilePictureUrl())
                         .build();
 
                 kafkaProducer.produceUserUpdate(userUpdateEvent);
@@ -145,6 +146,7 @@ public class UserManagementServiceImpl implements UserManagementService {
                         .firstName(updatedUser.getFirstName())
                         .lastName(updatedUser.getLastName())
                         .username(updatedUser.getUsername())
+                        .imageUrl(updatedUser.getProfilePictureUrl())
                         .specializations(specializationIds)
                         .build();
 


### PR DESCRIPTION
# 🚀 Pull Request: Send User Profile Picture in Roadmap Service

## ✅  Summary
This PR provides user event publishing functionality in `roadmap-service` including the profile-picture url.

## 📌  Features Add
- [x] Updated `UserManagementServiceImpl` to send `profilePictureUrl` in an event along other updated details when a user update their information.